### PR TITLE
feat: implement publish posts

### DIFF
--- a/src/module/implemention/blog-platform-uploader.ts
+++ b/src/module/implemention/blog-platform-uploader.ts
@@ -1,0 +1,41 @@
+import { Result } from "../../core/result";
+import type { BlogPlatform } from "../domain/blog-platform";
+import type { Translation } from "../domain/translation";
+import type { Translations } from "../domain/translations";
+import type { WebClient } from "../repository/web.client";
+
+export abstract class BlogPlatformUploader {
+	private static strategy: Map<string, BlogPlatformUploader> = new Map();
+	protected readonly client: WebClient;
+
+	protected constructor(client: WebClient) {
+		this.client = client;
+	}
+
+	/**
+	 * Register a new uploader for a specific blog platform.
+	 * @example
+	 * @param platform
+	 * @param instance
+	 */
+	static register(platform: BlogPlatform, instance: BlogPlatformUploader): void {
+		const platformKey = platform.toString();
+		if (BlogPlatformUploader.strategy.has(platformKey)) {
+			throw new Error(`Platform ${platform} is already registered`);
+		}
+		BlogPlatformUploader.strategy.set(platformKey, instance);
+	}
+
+	static get(platform: BlogPlatform): Result<BlogPlatformUploader> {
+		const instance = BlogPlatformUploader.strategy.get(platform.toString());
+		if (!instance) return Result.fail(`Platform ${platform} is not registered`);
+
+		return Result.success(instance);
+	}
+
+	abstract putUpload(posts: Translation): Promise<Translation>;
+
+	async uploadAll(posts: Translations): Promise<void> {
+		await Promise.all(posts.getAll().map((post) => this.putUpload(post)));
+	}
+}

--- a/src/module/implemention/blog-uploader-strategy/medium-uploader.ts
+++ b/src/module/implemention/blog-uploader-strategy/medium-uploader.ts
@@ -1,0 +1,69 @@
+import { PostUrl } from "@src/module/domain/post-url";
+import type { Translation } from "@src/module/domain/translation";
+import { BlogPlatformUploader } from "@src/module/implemention/blog-platform-uploader";
+import { BodyInserter, type WebClient } from "@src/module/repository/web.client";
+import { StringBuilder } from "@src/shared/util/string-builder";
+
+interface MediumUploaderOptions {
+	token: string;
+}
+/**
+ * @deprecated medium api closed
+ */
+class MediumUploader extends BlogPlatformUploader {
+	private userId: string | null = null;
+
+	constructor(
+		private readonly options: MediumUploaderOptions,
+		client: WebClient,
+	) {
+		super(client);
+	}
+
+	private async getUserId(): Promise<string> {
+		const result = await this.client.uri("https://api.medium.com/v1/me").retrieve();
+		if (result.statusCode !== 200) {
+			throw new Error("Medium API 호출에 실패했습니다.");
+		}
+		// @ts-ignore
+		return String(result.jsonBody?.data.id);
+	}
+
+	async putUpload(post: Translation): Promise<Translation> {
+		if (!this.userId) this.userId = await this.getUserId();
+
+		const response = await this.client
+			.uri(`https://api.medium.com/v1/users/${this.userId}/posts`)
+			.headers({
+				Authorization: `Bearer ${this.options.token}`,
+				"Content-Type": "application/json",
+			})
+			.body(
+				BodyInserter.fromJSON({
+					title: post.title.toString(),
+					contentFormat: "markdown",
+					content: new StringBuilder()
+						.appendLine(`#${post.title.toString()}`)
+						.appendLine()
+						.appendLine("## Published By Kaio-ken")
+						.appendLine()
+						.appendLine()
+						.appendLine()
+						.append(post.content.toString())
+						.toString(),
+					publishStatus: "public",
+				}),
+			)
+			.retrieve();
+		if (response.statusCode === 429) throw new Error("Medium API Rate Limit Over");
+		if (response.statusCode === 403) throw new Error("Medium API Forbidden");
+		if (response.statusCode !== 201) throw new Error(`Medium API Failed: ${response.statusCode}`);
+
+		const rawUrl = String(response.jsonBody.url);
+		const postUrlOrFailure = PostUrl.from(rawUrl);
+		if (postUrlOrFailure.isFailed) throw new Error(postUrlOrFailure.getReason());
+		post.putUploadData(postUrlOrFailure.getValue());
+
+		return post;
+	}
+}

--- a/src/module/implemention/blog-uploader-strategy/qiita-uploader.ts
+++ b/src/module/implemention/blog-uploader-strategy/qiita-uploader.ts
@@ -30,8 +30,8 @@ export class QiitaUploader extends BlogPlatformUploader {
 
 	async putUpload(post: Translation): Promise<Translation> {
 		const payload: QiitaUploadPayload = {
-			title: "test",
-			body: "hi",
+			title: post.title,
+			body: post.body,
 			tags: [
 				{ name: "test", versions: [] },
 				{ name: "rails", versions: [] },

--- a/src/module/implemention/blog-uploader-strategy/qiita-uploader.ts
+++ b/src/module/implemention/blog-uploader-strategy/qiita-uploader.ts
@@ -1,0 +1,68 @@
+import { PostUploadedDate } from "../../domain/post-uploaded-date";
+import { PostUrl } from "../../domain/post-url";
+import type { Translation } from "../../domain/translation";
+import { BodyInserter, type WebClient } from "../../repository/web.client";
+import { BlogPlatformUploader } from "../blog-platform-uploader";
+
+type QiitaUploadPayload = {
+	title: string;
+	body: string;
+	tags: { name: string; versions: string[] }[];
+	coediting?: boolean;
+	group_url_name?: string;
+	private?: boolean;
+	tweet?: boolean;
+	organization_url_name?: string | null;
+	slides?: boolean;
+};
+
+interface QiitaUploaderOptions {
+	token: string;
+}
+
+export class QiitaUploader extends BlogPlatformUploader {
+	constructor(
+		private readonly options: QiitaUploaderOptions,
+		client: WebClient,
+	) {
+		super(client);
+	}
+
+	async putUpload(post: Translation): Promise<Translation> {
+		const payload: QiitaUploadPayload = {
+			title: "test",
+			body: "hi",
+			tags: [
+				{ name: "test", versions: [] },
+				{ name: "rails", versions: [] },
+			],
+			// coediting: false,
+			// group_url_name: "dev",
+			private: false,
+			// tweet: false,
+			// organization_url_name: null,
+			// slides: false,
+		};
+
+		const response = await this.client
+			.uri("https://qiita.com/api/v2/items")
+			.headers({
+				Authorization: `Bearer ${this.options.token}`,
+				"Content-Type": "application/json",
+			})
+			.post()
+			.body(BodyInserter.fromJSON(payload))
+			.retrieve();
+		if (response.statusCode !== 201)
+			throw new Error(`Qiita API Failed: ${response.statusCode}, ${response.jsonBody.message}`);
+
+		const postUrlResult = PostUrl.from(String(response.jsonBody.url));
+		if (postUrlResult.isFailed) throw new Error(postUrlResult.getReason());
+
+		const postUploadedDateResult = PostUploadedDate.from(new Date(String(response.jsonBody.created_at)));
+		if (postUploadedDateResult.isFailed) throw new Error(postUploadedDateResult.getReason());
+
+		post.putUploadData(postUrlResult.getValue(), postUploadedDateResult.getValue());
+		return post;
+	}
+}

--- a/src/module/infra/github-actions/setup-blog-uploader.ts
+++ b/src/module/infra/github-actions/setup-blog-uploader.ts
@@ -1,0 +1,24 @@
+import { authConfig } from "@src/config/auth.config";
+import { BlogPlatform } from "@src/module/domain/blog-platform";
+import { githubFileReader } from "@src/module/implemention";
+import { BlogPlatformUploader } from "@src/module/implemention/blog-platform-uploader";
+import { QiitaUploader } from "@src/module/implemention/blog-uploader-strategy/qiita-uploader";
+import { AxiosClient } from "@src/module/repository/driver/axios-client";
+
+export async function setupBlogUploader() {
+	const metadata = await githubFileReader.getMetadata();
+
+	for (const blog of metadata.subscriberBlogs.getSubscribers()) {
+		switch (blog.platform.toString()) {
+			case BlogPlatform.values.qiita.toString(): {
+				BlogPlatformUploader.register(
+					blog.platform,
+					new QiitaUploader({ token: authConfig.QIITA_TOKEN }, new AxiosClient()),
+				);
+				break;
+			}
+			default:
+				throw new Error(`Unsupported blog platform: ${blog.platform}`);
+		}
+	}
+}

--- a/src/module/parser/sitemap-xml-parser.ts
+++ b/src/module/parser/sitemap-xml-parser.ts
@@ -1,0 +1,101 @@
+import { NullGuard } from "@src/core/null-guard";
+import type { BlogEntity } from "@src/module/domain/blog.entity";
+import type { PostEntity } from "@src/module/domain/post.entity";
+import { Sitemap } from "@src/module/domain/sitemap";
+import type { Translation } from "@src/module/domain/translation";
+import { UrlSet } from "@src/module/domain/url-set";
+import { UrlTag } from "@src/module/domain/url-tag";
+import { XhtmlTag } from "@src/module/domain/xhtml-tag";
+import { XmlDeclaration } from "@src/module/domain/xml-declaration";
+import { DateUtil } from "@src/shared/util/date.util";
+import { XMLParser } from "fast-xml-parser";
+
+export namespace SitemapXmlParser {
+	export function parseBlogUrl(blog: BlogEntity): UrlTag {
+		const tagOrError = UrlTag.create({ location: blog.url.toUrl() });
+		if (!tagOrError.isSucceed) throw new Error(tagOrError.getReason());
+
+		return tagOrError.getValue();
+	}
+
+	export function parseTranslationUrl(originalUrl: URL, translation: Translation): XhtmlTag {
+		const translationUrlOrNull = translation.url;
+		if (!translationUrlOrNull) throw new Error("Unuploaded post cannot parse to xml tag");
+		const tagOrFailed = XhtmlTag.create({
+			location: originalUrl,
+			language: translation.language,
+			href: translationUrlOrNull.toUrl(),
+		});
+
+		if (tagOrFailed.isFailed) throw new Error(tagOrFailed.getReason());
+
+		return tagOrFailed.getValue();
+	}
+
+	export function parsePostUrl(post: PostEntity): UrlTag {
+		const result = UrlTag.create({
+			location: post.url.toUrl(),
+			lastModified: new Date(),
+			changeFrequency: "monthly",
+			priority: 0.8,
+		});
+		if (result.isFailed) throw new Error(result.getReason());
+		const urlTag = result.getValue();
+
+		for (const translation of post.translationMap.getValues()) {
+			urlTag.addChild(SitemapXmlParser.parseTranslationUrl(post.url.toUrl(), translation));
+		}
+
+		return urlTag;
+	}
+	export function parsePostUrls(posts: PostEntity[]): UrlTag[] {
+		return posts.map((post) => SitemapXmlParser.parsePostUrl(post));
+	}
+
+	export function fromString(raw: string): Sitemap {
+		const parser = new XMLParser({ ignoreAttributes: false, attributeNamePrefix: "", trimValues: true });
+		const root = parser.parse(raw);
+
+		const declaration = root["?xml"];
+		const nullGuard = NullGuard.againstNullOrUndefinedBulk([
+			{ argument: declaration, argumentName: "XML declaration" },
+			{ argument: root.urlset, argumentName: "URL set" },
+		]);
+		if (nullGuard.isFailed) throw new Error(`Invalid XML format: ${nullGuard.getReason()}`);
+
+		const urlTags: UrlTag[] = [];
+		const urlset = root.urlset;
+		for (const rawUrlTag of Array(urlset.url).flat()) {
+			const urlTagOrFailed = UrlTag.create({
+				location: new URL(rawUrlTag.loc),
+				lastModified: rawUrlTag.lastmod ? DateUtil.fromString(rawUrlTag.lastmod) : undefined,
+				changeFrequency: rawUrlTag.changefreq,
+				priority: rawUrlTag.priority ? Number.parseFloat(rawUrlTag.priority) : undefined,
+			});
+			if (urlTagOrFailed.isFailed) throw new Error(`Failed to parse URL tag: ${urlTagOrFailed.getReason()}`);
+
+			const urlTag = urlTagOrFailed.getValue();
+
+			if (rawUrlTag["xhtml:link"]) {
+				const xhtmlTagOrFailed = XhtmlTag.create({
+					location: urlTag.location,
+					language: rawUrlTag["xhtml:link"].hreflang,
+					href: new URL(rawUrlTag["xhtml:link"].href),
+				});
+				if (xhtmlTagOrFailed.isFailed) throw new Error(`Failed to parse XHTML tag: ${xhtmlTagOrFailed.getReason()}`);
+
+				urlTag.addChild(xhtmlTagOrFailed.getValue());
+			}
+			urlTags.push(urlTag);
+		}
+		const urlSet = UrlSet.create({ xmlns: urlset.xmlns, urlSet: urlTags });
+
+		return Sitemap.from({
+			declaration: XmlDeclaration.create({
+				version: declaration.version,
+				encoding: declaration.encoding,
+			}),
+			urlSet: urlSet,
+		}).getValue();
+	}
+}

--- a/src/module/use-case/download-posts/download-posts.controller.ts
+++ b/src/module/use-case/download-posts/download-posts.controller.ts
@@ -16,7 +16,6 @@ export class DownloadPostsController extends BaseGithubActionController {
 
 			return this.complete();
 		} catch (e: unknown) {
-			// TODO: 예외처리
 			return this.fail(e);
 		}
 	}

--- a/src/module/use-case/publish-posts/index.ts
+++ b/src/module/use-case/publish-posts/index.ts
@@ -1,0 +1,6 @@
+import { githubFileReader, translationUploader } from "../../implemention";
+import { PublishPostsController } from "./publish-posts.controller";
+import { PublishPostsUseCase } from "./publish-posts.use-case";
+
+const publishPostsUseCase = new PublishPostsUseCase(githubFileReader, translationUploader);
+export const publishPostsController = new PublishPostsController(publishPostsUseCase);

--- a/src/module/use-case/publish-posts/publish-posts.controller.ts
+++ b/src/module/use-case/publish-posts/publish-posts.controller.ts
@@ -1,0 +1,32 @@
+import type { Metadata } from "@src/module/domain/metadata";
+import type { Sitemap } from "@src/module/domain/sitemap";
+import { PublishPostsExceptions } from "@src/module/use-case/publish-posts/publish-posts.exception";
+import type { PublishPostsUseCase } from "@src/module/use-case/publish-posts/publish-posts.use-case";
+import { BaseGithubActionController } from "@src/shared/infra/github-action/base-github-action-controller";
+
+export class PublishPostsController extends BaseGithubActionController {
+	constructor(private readonly useCase: PublishPostsUseCase) {
+		super();
+	}
+
+	protected async executeUseCase(metadata: Metadata, sitemap: Sitemap): Promise<void> {
+		try {
+			const result = await this.useCase.execute(metadata, sitemap);
+
+			if (result.isFailed) {
+				const exception = result.getFailure();
+
+				switch (exception.constructor) {
+					case PublishPostsExceptions.PublishNotSupportedPlatformException:
+						return this.clientError(exception.getReason());
+					default:
+						return this.fail("An unexpected error occurred.");
+				}
+			}
+
+			return this.complete();
+		} catch (error: unknown) {
+			return this.fail(error);
+		}
+	}
+}

--- a/src/module/use-case/publish-posts/publish-posts.exception.ts
+++ b/src/module/use-case/publish-posts/publish-posts.exception.ts
@@ -1,0 +1,10 @@
+import { Result } from "@src/core/result";
+import type { UseCaseException } from "@src/core/use-case.exception";
+
+export namespace PublishPostsExceptions {
+	export class PublishNotSupportedPlatformException extends Result<UseCaseException> {
+		constructor(platform: string) {
+			super(false, `The platform ${platform} is not supported for publishing posts`);
+		}
+	}
+}

--- a/src/module/use-case/publish-posts/publish-posts.use-case.ts
+++ b/src/module/use-case/publish-posts/publish-posts.use-case.ts
@@ -1,0 +1,76 @@
+import { EitherResult } from "@src/core/either-result";
+import type { Result } from "@src/core/result";
+import type { UseCase } from "@src/core/use-case";
+import type { UseCaseException } from "@src/core/use-case.exception";
+import type { BlogEntity } from "@src/module/domain/blog.entity";
+import { Blogs } from "@src/module/domain/blogs";
+import type { Metadata } from "@src/module/domain/metadata";
+import type { Sitemap } from "@src/module/domain/sitemap";
+import type { Translations } from "@src/module/domain/translations";
+import type { FileReader } from "@src/module/implemention/file.reader";
+import type { TranslationUploader } from "@src/module/implemention/translation-uploader";
+import { SitemapXmlParser } from "@src/module/parser/sitemap-xml-parser";
+import type { PublishPostsExceptions } from "@src/module/use-case/publish-posts/publish-posts.exception";
+
+interface EffectDto {
+	effected: number;
+	exceptions: Array<PublishPostsExceptions.PublishNotSupportedPlatformException>;
+}
+
+type UseCaseResponse = EitherResult<EffectDto, PublishPostsExceptions.PublishNotSupportedPlatformException>;
+
+export class PublishPostsUseCase implements UseCase<[Metadata, Sitemap], UseCaseResponse> {
+	constructor(
+		private readonly fileReader: FileReader,
+		private readonly translationUploader: TranslationUploader,
+	) {}
+
+	async execute(metadata: Metadata, sitemap: Sitemap): Promise<UseCaseResponse> {
+		const subscribers = metadata.subscriberBlogs.getAll();
+		const promises = subscribers.map((subscriber) => this.handleSubscriber(subscriber, sitemap));
+		const results = await Promise.allSettled(promises);
+
+		const successfulSubscribers: Array<BlogEntity> = [];
+		const exceptions: Array<Result<UseCaseException>> = [];
+
+		for (const result of results) {
+			if (result.status === "rejected") {
+				exceptions.push(result.reason);
+				continue;
+			}
+			successfulSubscribers.push(result.value);
+		}
+
+		metadata.subscriberBlogs = Blogs.of(successfulSubscribers).getValue();
+
+		return EitherResult.success({
+			effected: successfulSubscribers.length,
+			exceptions,
+		});
+	}
+
+	private async handleSubscriber(subscriber: BlogEntity, sitemap: Sitemap): Promise<BlogEntity> {
+		if (subscriber.isUnSubscriber()) {
+			return subscriber;
+		}
+
+		const uploadablePosts = await this.getUploadablePosts(subscriber);
+		if (uploadablePosts.isEmpty) {
+			return subscriber;
+		}
+
+		await this.translationUploader.uploadMany(subscriber, uploadablePosts);
+
+		const posts = await this.fileReader.getPostsByTranslations(uploadablePosts.getAll());
+		const tags = SitemapXmlParser.parsePostUrls(posts);
+		sitemap.urlSet.putUrls(tags);
+
+		subscriber.lastPublishedId = uploadablePosts.getLast().id;
+		return subscriber;
+	}
+
+	private async getUploadablePosts(subscriber: BlogEntity): Promise<Translations> {
+		const translations = await this.fileReader.readTranslations(subscriber.language);
+		return translations.getNewerThan(subscriber.lastPublishedId);
+	}
+}

--- a/test/unit/implemention/post-uploader.test.ts
+++ b/test/unit/implemention/post-uploader.test.ts
@@ -1,0 +1,86 @@
+import { QiitaUploader } from "@src/module/implemention/blog-uploader-strategy/qiita-uploader";
+import { DateUtil } from "@src/shared/util/date.util";
+import { TranslationMother } from "@test/fixture/translation.mother";
+import { WebClientStub } from "@test/stub/web-client.stub";
+
+describe("BlogPlatformUploader Integration Test", () => {
+	let webClient: WebClientStub;
+
+	beforeEach(() => {
+		webClient = new WebClientStub();
+	});
+
+	describe("QiitaUploader", () => {
+		let qiitaUploader: QiitaUploader;
+
+		beforeEach(() => {
+			qiitaUploader = new QiitaUploader({ token: "test_token" }, webClient);
+		});
+
+		it("upload post.", async () => {
+			const responseBody = {
+				rendered_body: "<h1>Example</h1>",
+				body: "# Example",
+				coediting: false,
+				comments_count: 100,
+				created_at: "2000-01-01T00:00:00+00:00",
+				group: {
+					created_at: "2000-01-01T00:00:00+00:00",
+					description: "This group is for developers.",
+					name: "Dev",
+					private: false,
+					updated_at: "2000-01-01T00:00:00+00:00",
+					url_name: "dev",
+				},
+				id: "c686397e4a0f4f11683d",
+				likes_count: 100,
+				private: false,
+				reactions_count: 100,
+				stocks_count: 100,
+				tags: [
+					{
+						name: "Ruby",
+						versions: ["0.0.1"],
+					},
+				],
+				title: "Example title",
+				updated_at: "2000-01-01T00:00:00+00:00",
+				url: "https://qiita.com/Qiita/items/c686397e4a0f4f11683d",
+				user: {
+					description: "Hello, world.",
+					facebook_id: "qiita",
+					followees_count: 100,
+					followers_count: 200,
+					github_login_name: "qiitan",
+					id: "qiita",
+					items_count: 300,
+					linkedin_id: "qiita",
+					location: "Tokyo, Japan",
+					name: "Qiita キータ",
+					organization: "Qiita Inc.",
+					permanent_id: 1,
+					profile_image_url:
+						"https://s3-ap-northeast-1.amazonaws.com/qiita-image-store/0/88/ccf90b557a406157dbb9d2d7e543dae384dbb561/large.png?1575443439",
+					team_only: false,
+					twitter_screen_name: "qiita",
+					website_url: "https://qiita.com",
+				},
+				page_views_count: 100,
+				team_membership: {
+					name: "Qiita キータ",
+				},
+				organization_url_name: "qiita-inc",
+				slide: false,
+			};
+			webClient.pushResponse({ statusCode: 201, body: JSON.stringify(responseBody) });
+			const translation = TranslationMother.create();
+
+			const effected = await qiitaUploader.putUpload(translation);
+
+			expect(webClient.urls[0]).toBe("https://qiita.com/api/v2/items");
+			expect(webClient.methods[0]).toEqual("POST");
+			expect(effected.url?.toString()).toBe(responseBody.url);
+			expect(effected.uploadedAt?.toString()).toBe(DateUtil.formatYYYYMMDD(new Date(responseBody.created_at)));
+		});
+	});
+});

--- a/test/unit/parser/sitemap-xml-parser.test.ts
+++ b/test/unit/parser/sitemap-xml-parser.test.ts
@@ -1,0 +1,141 @@
+import { AutoIncrementManager } from "@src/core/auto-increment-manager";
+import { UniqueEntityId } from "@src/core/unique-identifier";
+import { BlogPlatform } from "@src/module/domain/blog-platform";
+import { BlogTitle } from "@src/module/domain/blog-title";
+import { BlogType } from "@src/module/domain/blog-type";
+import { BlogUrl } from "@src/module/domain/blog-url";
+import { BlogEntity } from "@src/module/domain/blog.entity";
+import { Language } from "@src/module/domain/language";
+import { PostContent } from "@src/module/domain/post-content";
+import { PostTitle } from "@src/module/domain/post-title";
+import { PostUploadedDate } from "@src/module/domain/post-uploaded-date";
+import { PostUrl } from "@src/module/domain/post-url";
+import { PostEntity } from "@src/module/domain/post.entity";
+import { Translation } from "@src/module/domain/translation";
+import { TranslationMap } from "@src/module/domain/translation-map";
+import { SitemapXmlParser } from "@src/module/parser/sitemap-xml-parser";
+
+describe("SitemapXmlParser", () => {
+	beforeAll(() => {
+		AutoIncrementManager.instance.register(BlogEntity.ENTITY_KEY);
+		AutoIncrementManager.instance.register(PostEntity.ENTITY_KEY);
+	});
+
+	describe("parseBlogUrl", () => {
+		it("should create a valid URL tag for a blog", () => {
+			const blogUrl = BlogUrl.from("https://example.com").getValue();
+			const blogTitle = BlogTitle.create("Test Blog").getValue();
+			const blogType = BlogType.create("SUBSCRIBER").getValue();
+			const blogPlatform = BlogPlatform.from("medium").getValue();
+			const language = Language.from("en").getValue();
+
+			const blog = BlogEntity.create({
+				url: blogUrl,
+				title: blogTitle,
+				type: blogType,
+				platform: blogPlatform,
+				language,
+			}).getValue();
+
+			const urlTag = SitemapXmlParser.parseBlogUrl(blog);
+			expect(urlTag.location.toString()).toBe("https://example.com/");
+		});
+	});
+
+	describe("parseTranslationUrl", () => {
+		it("should create a valid XHTML tag for a translation", () => {
+			const originalUrl = new URL("https://example.com/post");
+			const language = Language.from("en").getValue();
+			const translationUrl = PostUrl.from("https://example.com/en/post").getValue();
+
+			const translation = Translation.create({
+				language,
+				url: translationUrl,
+				postId: UniqueEntityId.create(1),
+				title: PostTitle.from("Test Post").getValue(),
+				content: PostContent.from("Test content").getValue(),
+				uploadedAt: PostUploadedDate.from(new Date()).getValue(),
+			}).getValue();
+
+			const xhtmlTag = SitemapXmlParser.parseTranslationUrl(originalUrl, translation);
+			expect(xhtmlTag.location.toString()).toBe("https://example.com/post");
+		});
+
+		it("should throw error for unuploaded post", () => {
+			const originalUrl = new URL("https://example.com/post");
+			const language = Language.from("en").getValue();
+
+			const translation = Translation.create({
+				language,
+				url: null,
+				postId: UniqueEntityId.create(1),
+				title: PostTitle.from("Test Post").getValue(),
+				content: PostContent.from("Test content").getValue(),
+				uploadedAt: PostUploadedDate.from(new Date()).getValue(),
+			}).getValue();
+
+			expect(() => SitemapXmlParser.parseTranslationUrl(originalUrl, translation)).toThrow(
+				"Unuploaded post cannot parse to xml tag",
+			);
+		});
+	});
+
+	describe("parsePostUrl", () => {
+		it("should create a valid URL tag for a post with translations", () => {
+			const postUrl = PostUrl.from("https://example.com/post").getValue();
+			const language = Language.from("en").getValue();
+			const translationUrl = PostUrl.from("https://example.com/en/post").getValue();
+
+			const translation = Translation.create({
+				language,
+				url: translationUrl,
+				postId: UniqueEntityId.create(1),
+				title: PostTitle.from("Test Post").getValue(),
+				content: PostContent.from("Test content").getValue(),
+				uploadedAt: PostUploadedDate.from(new Date()).getValue(),
+			}).getValue();
+
+			const translations = new TranslationMap(new Map([[language, translation]]));
+
+			const post = PostEntity.create({
+				url: postUrl,
+				title: PostTitle.from("Test Post").getValue(),
+				content: PostContent.from("Test content").getValue(),
+				uploadedAt: PostUploadedDate.from(new Date()).getValue(),
+				language,
+				translations,
+			}).getValue();
+
+			const urlTag = SitemapXmlParser.parsePostUrl(post);
+			expect(urlTag.location.toString()).toBe("https://example.com/post");
+		});
+	});
+
+	describe("fromString", () => {
+		it("should parse a valid sitemap XML string", () => {
+			const rawXml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+	<url>
+		<loc>https://example.com/post1</loc>
+		<lastmod>2024-03-20</lastmod>
+		<changefreq>monthly</changefreq>
+		<priority>0.8</priority>
+		<xhtml:link rel="alternate" hreflang="en" href="https://example.com/en/post1" />
+	</url>
+</urlset>`;
+
+			const sitemap = SitemapXmlParser.fromString(rawXml);
+			expect(sitemap.urlSet).toBeDefined();
+		});
+
+		it("should throw error for invalid XML format", () => {
+			const invalidXml = "invalid xml";
+			expect(() => SitemapXmlParser.fromString(invalidXml)).toThrow("Invalid XML format");
+		});
+
+		it("should throw error for missing required elements", () => {
+			const incompleteXml = `<?xml version="1.0" encoding="UTF-8"?>`;
+			expect(() => SitemapXmlParser.fromString(incompleteXml)).toThrow("Invalid XML format");
+		});
+	});
+});


### PR DESCRIPTION
This PR introduces the "publish posts" feature by adding unit tests, implementing the publish posts use case and controller, and integrating blog uploader strategies. Key changes include additions of unit tests for the sitemap XML parser and post uploader, implementation of the publish posts use case and controller, and setup of uploader strategies (Qiita and Medium).


File | Description
-- | --
test/unit/parser/sitemap-xml-parser.test.ts | Added tests for sitemap XML parsing functionality.
test/unit/implemention/post-uploader.test.ts | Added integration test for the Qiita uploader.
src/module/use-case/publish-posts/* | Implemented use case, controller, exception, and index registration for publishing posts.
src/module/parser/sitemap-xml-parser.ts | Added parser functions for building sitemap from XML.
src/module/infra/github-actions/setup-blog-uploader.ts | Configured blog uploader registration based on blog platform.
src/module/implemention/blog-uploader-strategy/* | Implemented Qiita and deprecated Medium uploader strategies, along with platform uploader abstraction.

